### PR TITLE
Topic/rework launching application

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -25,7 +25,7 @@ Checkout [Installation Guide](docs/installation-guide.md)
 Install build dependencies
 
 ```bash
-sudo apt install -y qt5-default qt5-qmake qtbase5-dev qtbase5-dev-tools qttools5-dev qtdeclarative5-devqml-module-qt-labs-folderlistmodel qml-module-qtquick-layouts qml-module-qtquick-controls2 qml-module-qtquick-window2 qml-module-qtquick2 qml-module-qtgraphicaleffects libqt5quickcontrols2-5 libqt5quicktemplates2-5 qml-module-qtquick-templates2
+sudo apt install -y qt5-default qt5-qmake qtbase5-dev qtbase5-dev-tools qttools5-dev qtdeclarative5-devqml-module-qt-labs-folderlistmodel qml-module-qtquick-layouts qml-module-qtquick-controls2 qml-module-qtquick-window2 qml-module-qtquick2 qml-module-qtgraphicaleffects libqt5quickcontrols2-5 libqt5quicktemplates2-5 qml-module-qtquick-templates2 qml-module-qtquick-dialogs qml-module-qtquick-controls
 ```
 
 Make
@@ -38,7 +38,7 @@ make
 For raspbian bullseye, you need:
 
 ```bash
-sudo apt -y install qtdeclarative5-dev qt5-qmake qtbase5-dev qtbase5-dev-tools qttools5-dev qml-module-qt-labs-folderlistmodel qml-module-qtquick-layouts qml-module-qtquick-controls2 qml-module-qtquick-window2 qml-module-qtquick2 qml-module-qtgraphicaleffects libqt5quickcontrols2-5 libqt5quicktemplates2-5 qml-module-qtquick-templates2
+sudo apt -y install qtdeclarative5-dev qt5-qmake qtbase5-dev qtbase5-dev-tools qttools5-dev qml-module-qt-labs-folderlistmodel qml-module-qtquick-layouts qml-module-qtquick-controls2 qml-module-qtquick-window2 qml-module-qtquick2 qml-module-qtgraphicaleffects libqt5quickcontrols2-5 libqt5quicktemplates2-5 qml-module-qtquick-templates2 qml-module-qtquick-dialogs qml-module-qtquick-controls
 qmake -qt=qt5
 make
 ```

--- a/Readme.md
+++ b/Readme.md
@@ -35,4 +35,12 @@ qmake
 make
 ```
 
+For raspbian bullseye, you need:
+
+```bash
+sudo apt -y install qtdeclarative5-dev qt5-qmake qtbase5-dev qtbase5-dev-tools qttools5-dev qml-module-qt-labs-folderlistmodel qml-module-qtquick-layouts qml-module-qtquick-controls2 qml-module-qtquick-window2 qml-module-qtquick2 qml-module-qtgraphicaleffects libqt5quickcontrols2-5 libqt5quicktemplates2-5 qml-module-qtquick-templates2
+qmake -qt=qt5
+make
+```
+
 And there you go.

--- a/debian/raspad-launcher/bin/raspad-launcher-helper
+++ b/debian/raspad-launcher/bin/raspad-launcher-helper
@@ -8,8 +8,8 @@
 # If raspad.conf is not exist, means it's first boot up, don't show raspad-launcher, incase of launcher shows over config
 
 PID=`pidof raspad-launcher`
-if [ ! -e $PID ]; then
-	kill PID
+if [ -n "$PID" ]; then
+	kill $PID
 else
 	raspad-launcher&
 fi

--- a/debian/raspad-launcher/install
+++ b/debian/raspad-launcher/install
@@ -25,6 +25,8 @@ DEPENDENCIES = [
     "libqt5quickcontrols2-5",
     "libqt5quicktemplates2-5",
     "qml-module-qtquick-templates2",
+    "qml-module-qtquick-dialogs",
+    "qml-module-qtquick-controls",
 ]
 
 def install():

--- a/docs/installation-guide.md
+++ b/docs/installation-guide.md
@@ -64,10 +64,15 @@ Install qt dependencies:
 
 ```bash
 sudo apt update
-sudo apt install qml-module-qt-labs-folderlistmodel qml-module-qtquick-layouts qml-module-qtquick-controls2 qml-module-qtquick-window2 qml-module-qtquick2 qml-module-qtgraphicaleffects libqt5quickcontrols2-5 libqt5quicktemplates2-5 qml-module-qtquick-templates2
+sudo apt install qml-module-qt-labs-folderlistmodel qml-module-qtquick-layouts qml-module-qtquick-controls2 qml-module-qtquick-window2 qml-module-qtquick2 qml-module-qtgraphicaleffects libqt5quickcontrols2-5 libqt5quicktemplates2-5 qml-module-qtquick-templates2 qml-module-qtquick-dialogs qml-module-qtquick-controls
 ```
 
-> You don't need this if you are just upgrading.
+> If you are just upgrading, you don't need this. But you need to install the following new dependency, if you get the error message that the module QtQuick.Dialogs is missing:
+
+```bash
+sudo apt update
+sudo apt install qml-module-qtquick-dialogs qml-module-qtquick-controls
+```
 
 Copy RasPad Launcher related files including binary file, desktop profile, icon, raspad-launcher-helper and raspad-faq desktop profile.
 

--- a/launcher/qml/execvalueparser.js
+++ b/launcher/qml/execvalueparser.js
@@ -1,0 +1,184 @@
+
+// Provide parsing functions for Exec value in desktop files.
+
+.pragma library
+
+/* On a first level translate the two character combinations '\n', '\r', '\s',
+ * '\t' and '\\' in NEWLINE, CARRIAGE RETURN, SPACE, TAB and BACKSLASH,
+ * respectively.
+ */
+function  doEscapingFirstLevel(text) {
+    var replaced = '';
+    for (var i = 0; i < text.length; i++) {
+        var ch = ''
+        if (text[i] =='\\') {
+            if (i === text.length - 1) {
+                break;
+            }
+            i++
+            var nextChar = text[i];
+            if (nextChar === 'n') {
+                ch = '\n';
+            } else if (nextChar === 'r') {
+                ch = '\r';
+            } else if (nextChar === 's') {
+                ch = ' ';
+            } else if (nextChar === 't') {
+                ch = '\t';
+            } else if (nextChar === '\\') {
+                ch = '\\';
+            } else {
+                ch = '\\'
+                i--;
+            }
+        } else {
+           ch = text[i];
+        }
+        replaced += ch;
+    }
+    return replaced;
+}
+
+/* Replace Exec Value Field Codes '%i', '%c', '%k' and '%%' by the values
+ * explained in
+ * https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#exec-variables
+ * and remove all other two character combination starting with '%'.
+ */
+function replaceFieldCodes(text, appDataObj) {
+    var replaced = '';
+    var i = 0;
+    while (i < text.length) {
+        var next = text.indexOf('%', i)
+        if (next !== -1) {
+            var code = '';
+            var field = '';
+            if (next < text.length - 1) {
+                var code = text[next + 1];
+            }
+            if (code === 'i') {
+                field = '--icon ' + appDataObj.appIcon;
+            } else if (code === 'c') {
+                field = "'" + appDataObj.displayName + "'";
+            } else if (code === 'k') {
+                var path = appDataObj.appUrl;
+                field = path.slice(0, path.lastIndexOf('/'))
+            } else if (code === '%') {
+                field = '%';
+            }
+            // $f, %F, %u, %U are not used with a file list and must be
+            // removed, as well as all other codes (deprecated and undefined).
+            replaced += text.slice(i, next) + field;
+            i = next + 2;
+        } else {
+            replaced += text.slice(i);
+            break;
+        }
+    }
+    return replaced;
+}
+
+function isWhiteSpace(ch) {
+    return ch === ' ' || ch === '\t' || ch === '\n'
+}
+
+/* On a second level translate two character escape sequences into one character,
+ * respecting quoting and argument splitting at unquoted whitespace.
+ */
+function doEscapingSecondLevelAndSplitArguments(text) {
+    var args = [];
+    var arg = '';
+    // true, if parsing an argument.
+    var inArg = false;
+    // quoted == 0, being in an unquoted section.
+    // quoted == 1, being in a single quoted section.
+    // quoted == 2, being in a double quoted section.
+    var quoted = 0;
+    for (var i = 0; i < text.length; i++) {
+        var ch = text[i];
+        if (isWhiteSpace(ch)) {
+            if (inArg) {
+                if (quoted) {
+                    arg += ch;
+                } else {
+                    args.push(arg);
+                    arg = '';
+                    inArg = false;
+                }
+            }
+            continue;
+        }
+        if (!inArg) {
+            inArg = true
+        }
+        if (ch === "'") {
+            if (quoted === 0) {
+                quoted = 1;
+            } else if (quoted === 1) {
+                quoted = 0;
+            } else { // quoted === 2
+                arg += ch;
+            }
+        } else if (ch === '"') {
+            if (quoted === 0) {
+                quoted = 2;
+            } else if (quoted === 2) {
+                quoted = 0;
+            } else { // quoted === 1
+                arg += ch;
+            }
+        } else if (ch === '\\') {
+            if (quoted === 0) {
+                if (i == text.length - 1) {
+                    // Invalid Exec value.
+                    return ['']
+                }
+                i++;
+                next = text[i];
+                if (next !== '\n') {
+                    arg += next;
+                }
+            } else if (quoted === 1) {
+                arg += ch;
+            } else { // quoted === 2
+                if (i == text.length - 1) {
+                    // Invalid Exec value.
+                    return ['']
+                }
+                i++;
+                var next = text[i];
+                if (next === '"' || next === '\\' || next === '$'
+                     || next === '`' || next === '\n') {
+                    arg += next;
+                } else {
+                    arg += ch + next;
+                }
+            }
+        } else {
+            arg += ch;
+        }
+    }
+    if (quoted) {
+        // Invalid Exec value.
+        return ['']
+    } else {
+        if (inArg) {
+            args.push(arg)
+        }
+        return args
+    }
+}
+
+/* The actual Exec value parsing function.
+ * It takes an object from the appData application dictionary of main.qml.
+ * Returns the list of translated and splitted arguments.
+ * First argument is the executable, and is '' in invalid execValue.
+ * Returns an empty list, when execValue just consists of whitespace,
+ * or Exec key was not present in desktop file.
+ */
+function parseCommandLine(appDataObj) {
+    var execValue = appDataObj.appExec;
+    var escaped1 = doEscapingFirstLevel(execValue);
+    var withFields = replaceFieldCodes(escaped1, appDataObj);
+    var arguments = doEscapingSecondLevelAndSplitArguments(withFields)
+    return arguments
+}

--- a/launcher/qml/main.qml
+++ b/launcher/qml/main.qml
@@ -30,7 +30,7 @@ ApplicationWindow {
     property string langName: ""
     property var appData: {}
     property var categoriedAppList: {
-        "Home": ["Scratch 3", "Ezblock Studio", "Chromium Web Browser", "Minecraft Pi", "mu", "LibreOffice Writer", "LibreOffice Calc", "LibreOffice Impress", "File Manager PCManFM", "LXTerminal", "FAQ"],
+        "Home": ["scratch3.desktop", "Ezblock Studio ???.desktop", "chromium-browser.desktop", "minecraft-pi.desktop", "mu.codewith.editor.desktop", "libreoffice-writer.desktop", "libreoffice-calc.desktop", "libreoffice-impress.desktop", "pcmanfm.desktop", "lxterminal.desktop", "raspad-faq.desktop"],
         "Programming": [],
         "Education": [],
         "Office": [],
@@ -55,8 +55,8 @@ ApplicationWindow {
         "Help": ["Help"],
         "Preferences": ["Settings"]
     }
-    property var blacklist: ["Squeak", "Wolfram"]
-    property var whitelist: ["Screen Configuration", "Bookshelf"]
+    property var blacklist: ["squeak.desktop", "wolfram-language.desktop"]
+    property var whitelist: ["arandr.desktop", "rp-bookshelf.desktop"]
     property var currentCategory: "Home"
 
     property string errorNetwork: qsTr("Network Error")
@@ -455,6 +455,7 @@ ApplicationWindow {
             }
 
             var contents = result.split("\n");
+            var fileID = "";
             var name = "";
             var localName = "";
             var genericName = "";
@@ -541,6 +542,8 @@ ApplicationWindow {
                 }
             }
             url = url.toString().slice(7);
+            var urllist = url.split("/")
+            fileID = urllist[urllist.length - 1];
             displayName = name;
             // if (genericName !== "" && genericName.length < 25){
             //     displayName = genericName;
@@ -548,20 +551,20 @@ ApplicationWindow {
             if (localName !== "") {
                 displayName = localName;
             }
-            if (blacklist.indexOf(name) !== -1) {
+            if (blacklist.indexOf(fileID) !== -1) {
                 isShow = false;
             }
-            if (whitelist.indexOf(name) !== -1) {
+            if (whitelist.indexOf(fileID) !== -1) {
                 isWhiteListed = true;
-                // log("White List: " + name);
+                // log("White List: " + fileID);
             }
-            if (appData[name]) {
-                // application name has been already seen.
+            if (appData[fileID]) {
+                // application fileID has been already seen.
                 continue;
             }
             var added = false;
-            appData[name] = {
-                "appName": name,
+            appData[fileID] = {
+                "appName": fileID,
                 "displayName": displayName,// Todo: add display name translation
                 "appCategories": categories,
                 "appIcon": icon,
@@ -570,16 +573,16 @@ ApplicationWindow {
                 "appParam": param,
                 "appIsShow" : isShow || isWhiteListed
             }
-            // log("appData[" + name + "]:")
-            // logObj(appData[name]);
+            // log("appData[" + fileID + "]:")
+            // logObj(appData[fileID]);
             // log("categories.length: " + categories.length);
             // log("categories: ");
             // logList(categories);
 
             for (var l = 0; l < categories.length; l++) {
                 for (category in categoryRule) {
-                    if (categoryRule[category].indexOf(categories[l]) !== -1 && categoriedAppList[category].indexOf(name) === -1) {
-                        categoriedAppList[category].push(name);
+                    if (categoryRule[category].indexOf(categories[l]) !== -1 && categoriedAppList[category].indexOf(fileID) === -1) {
+                        categoriedAppList[category].push(fileID);
                         added = true;
                         break;
                     }

--- a/launcher/qml/main.qml
+++ b/launcher/qml/main.qml
@@ -374,6 +374,16 @@ ApplicationWindow {
                             }
                             var executable = result[0];
                             var arguments = result.slice(1);
+                            if (!fileinfo.exexcutableFileExists(executable)) {
+                                messageBox.text = "Invalid desktop file: '" + appUrl + "'";
+                                messageBox.open();
+                                return;
+                            }
+                            if (appInTerminal) {
+                                executable = "lxterminal"
+                                arguments = result;
+                                arguments.unshift("-e");
+                            }
                             process.setProgram(executable);
                             process.setArguments(arguments);
                             if (appPath) {
@@ -384,7 +394,7 @@ ApplicationWindow {
                             if (process.startDetached()) {
                                killTimer.start()
                             } else {
-                               messageBox.text = "Invalid desktop file: '" + appUrl + "'";
+                               messageBox.text = "Error starting command of desktop file: '" + appUrl + "'";
                                messageBox.open();
                             }
                         }
@@ -497,6 +507,7 @@ ApplicationWindow {
             var path = "";
             var categories = [];
             var desktopType = "";
+            var inTerminal = false;
             var isShow = true;
             var isWhiteListed = false;
 
@@ -550,7 +561,7 @@ ApplicationWindow {
                     }
                 } else if (arg === "Terminal") {
                     if (value === "true") {
-                        isShow = false;
+                        inTerminal = true;
                     }
                 } else if (arg === "NoDisplay") {
                     // log("NoDisplay true: " + url);
@@ -587,6 +598,7 @@ ApplicationWindow {
                 "appUrl": url,
                 "appExec": exec,
                 "appPath": path,
+                "appInTerminal": inTerminal,
                 "appIsShow" : isShow || isWhiteListed
             }
             // log("appData[" + fileID + "]:")
@@ -716,6 +728,7 @@ ApplicationWindow {
             log("Icon: " + app.appIcon);
             log("Exec: " + app.appExec);
             log("Path: " + app.appPath);
+            log("Terminal: " + app.appInTerminal);
             log("isShow: " + app.appIsShow);
         }
     }

--- a/launcher/qml/main.qml
+++ b/launcher/qml/main.qml
@@ -21,8 +21,9 @@ ApplicationWindow {
     property int iconGridHeight: 200
     property int iconWidth: 130
     property int iconHeight: 130
-    property bool systemApplicationsFolderListDone: false
     property bool userApplicationsFolderListDone: false
+    property bool raspiUiOverridesApplicationsFolderListDone: false
+    property bool systemApplicationsFolderListDone: false
     property bool isLoadApplicationTriggered: false
 
     property int lang
@@ -424,6 +425,15 @@ ApplicationWindow {
             loadApplicationTimer.start();
         }
     }
+    // 用户安装APP的文件获取模型
+    FolderListModel {
+        id: raspiUiOverridesApplicationsFolderList
+        folder: "file:///usr/share/raspi-ui-overrides/applications"
+        nameFilters: ["*.desktop"]
+        Component.onCompleted: {
+            loadApplicationTimer.start();
+        }
+    }
 
     function loadFromFolderListModel(folderList) {
         // log("loadFromFolderListModel(")
@@ -742,20 +752,26 @@ ApplicationWindow {
             if (isLoadApplicationTriggered) {
                 return;
             }
-            // if systemApplicationsFolderList is not Ready, Try again
-            if (systemApplicationsFolderList.status !== FolderListModel.Ready) {
-                loadApplicationTimer.start();
-                return;
-            }
             // if userApplicationsFolderList is not Ready, Try again
             if (userApplicationsFolderList.status !== FolderListModel.Ready) {
                 loadApplicationTimer.start();
                 return;
             }
+            // if raspiUiOverridesApplicationsFolderList is not Ready, Try again
+            if (raspiUiOverridesApplicationsFolderList.status !== FolderListModel.Ready) {
+                loadApplicationTimer.start();
+                return;
+            }
+            // if systemApplicationsFolderList is not Ready, Try again
+            if (systemApplicationsFolderList.status !== FolderListModel.Ready) {
+                loadApplicationTimer.start();
+                return;
+            }
             isLoadApplicationTriggered = true;
             appData = {};
-            loadFromFolderListModel(systemApplicationsFolderList);
             loadFromFolderListModel(userApplicationsFolderList);
+            loadFromFolderListModel(raspiUiOverridesApplicationsFolderList);
+            loadFromFolderListModel(systemApplicationsFolderList);
             isLoadApplicationTriggered = false;
         }
     }

--- a/launcher/qml/main.qml
+++ b/launcher/qml/main.qml
@@ -237,8 +237,14 @@ ApplicationWindow {
                 MouseArea {
                     anchors.fill: parent
                     onClicked: {
-                        process.start("lxde-pi-shutdown-helper", [])
-                        timer.start()
+                        process.setProgram("lxde-pi-shutdown-helper");
+                        process.setArguments([]);
+                        process.setWorkingDirectoryHome()
+                        process.setStandardFilesToNull();
+
+                        if (process.startDetached()) {
+                            Qt.quit();
+                        }
                     }
                 }
                 Image {
@@ -397,24 +403,12 @@ ApplicationWindow {
                             process.setStandardFilesToNull();
 
                             if (process.startDetached()) {
-                               killTimer.start()
+                               Qt.quit();
                             } else {
                                messageBox.text = "Error starting command of desktop file: '" + appUrl + "'";
                                messageBox.open();
                             }
                         }
-                    }
-                    Timer {
-                        id: killTimer
-                        interval: 500
-                        running: false
-                        onTriggered: {
-                            // log("killTimer: Kill myself")
-                            processkill.start("killall", ["raspad-launcher"])
-                        }
-                    }
-                    Process {
-                        id: processkill
                     }
                 }
             }
@@ -815,16 +809,6 @@ ApplicationWindow {
             loadFromFolderListModel(systemApplicationsFolderList);
             reloadAppList();
             isLoadApplicationTriggered = false;
-        }
-    }
-
-    // To kill itself after launcher an application
-    Timer {
-        id: timer
-        interval: 100
-        running: false
-        onTriggered: {
-            process.start("killall", ["raspad-launcher"])
         }
     }
 

--- a/launcher/qml/main.qml
+++ b/launcher/qml/main.qml
@@ -447,6 +447,13 @@ ApplicationWindow {
             //     log("Ignore: " + url)
             //     continue
             // }
+            var filePath = url.toString().slice(7);
+            var urllist = filePath.split("/")
+            var fileID = urllist[urllist.length - 1];
+            if (appData[fileID]) {
+                // application fileID has been already seen.
+                continue;
+            }
             var result = readFile(url, true);
 
             if (result === false) {
@@ -455,7 +462,6 @@ ApplicationWindow {
             }
 
             var contents = result.split("\n");
-            var fileID = "";
             var name = "";
             var localName = "";
             var genericName = "";
@@ -541,9 +547,7 @@ ApplicationWindow {
                     }
                 }
             }
-            url = url.toString().slice(7);
-            var urllist = url.split("/")
-            fileID = urllist[urllist.length - 1];
+            url = filePath
             displayName = name;
             // if (genericName !== "" && genericName.length < 25){
             //     displayName = genericName;
@@ -557,10 +561,6 @@ ApplicationWindow {
             if (whitelist.indexOf(fileID) !== -1) {
                 isWhiteListed = true;
                 // log("White List: " + fileID);
-            }
-            if (appData[fileID]) {
-                // application fileID has been already seen.
-                continue;
             }
             var added = false;
             appData[fileID] = {

--- a/launcher/qml/main.qml
+++ b/launcher/qml/main.qml
@@ -669,25 +669,23 @@ ApplicationWindow {
         appDrawList.clear();
         // log("loader.visible: " + loader.visible)
         if (loader.visible) {
-            loadApplicationTimer.start();
             loader.visible = false;
             loader.source = "";
             appDraw.visible = true;
-        } else {
-            if (!appData) {
-                return;
-            }
-            var programs = categoriedAppList[currentCategory];
-            // log("programs: " + programs);
-            // log("programs.length: " + programs.length);
-            for (var i = 0; i < programs.length; i++) {
-                var appName = programs[i];
-                var app = appData[appName];
-                // log("app:");
-                // logObj(app);
-                if (app && app.appIsShow) {
-                    appDrawList.append(app);
-                }
+        }
+        if (!appData) {
+            return;
+        }
+        var programs = categoriedAppList[currentCategory];
+        // log("programs: " + programs);
+        // log("programs.length: " + programs.length);
+        for (var i = 0; i < programs.length; i++) {
+            var appName = programs[i];
+            var app = appData[appName];
+            // log("app:");
+            // logObj(app);
+            if (app && app.appIsShow) {
+                appDrawList.append(app);
             }
         }
     }

--- a/launcher/qml/main.qml
+++ b/launcher/qml/main.qml
@@ -391,6 +391,11 @@ ApplicationWindow {
                             } else {
                                 process.setWorkingDirectoryHome()
                             }
+                            // Detach process from current stdin, stdout,
+                            // stderr, so that especially console programs
+                            // don't clutter the console of our launcher.
+                            process.setStandardFilesToNull();
+
                             if (process.startDetached()) {
                                killTimer.start()
                             } else {

--- a/launcher/qml/main.qml
+++ b/launcher/qml/main.qml
@@ -620,6 +620,7 @@ ApplicationWindow {
             "/usr/share/icons/hicolor/64x64/apps/",
             "/usr/share/icons/hicolor/48x48/apps/",
             "/usr/share/icons/hicolor/32x32/apps/",
+            "/usr/share/icons/hicolor/scalable/apps/",
             "/usr/share/icons/gnome/256x256/apps/",
             "/usr/share/icons/gnome/128x128/apps/",
             "/usr/share/icons/gnome/64x64/apps/",
@@ -631,7 +632,15 @@ ApplicationWindow {
             "/usr/share/pixmaps/"
         ];
         for (var i = 0; i < testList.length; i++) {
-            var path = "file://" + testList[i] + icon + ".png"
+            var path_pre = "file://" + testList[i] + icon
+            var path = path_pre
+            if (icon.indexOf(".png") == -1 && icon.indexOf(".svg") == -1) {
+                path = path_pre + ".png"
+                if (isFileExist(path)) {
+                    return path
+                }
+                path = path_pre + ".svg"
+            }
             if (isFileExist(path)) {
                 return path
             }

--- a/launcher/qml/main.qml
+++ b/launcher/qml/main.qml
@@ -384,7 +384,7 @@ ApplicationWindow {
                     }
                 }
             }
-            Component.onCompleted: reloadAppList(qsTr("Home"))
+            Component.onCompleted: reloadAppList(qsTr(currentCategory))
         }
     }
 

--- a/launcher/qml/main.qml
+++ b/launcher/qml/main.qml
@@ -6,6 +6,7 @@ import QtQuick.Window 2.2
 import Qt.labs.folderlistmodel 2.0
 import QtQuick.Dialogs 1.1
 import "execvalueparser.js" as Parser
+import FileInfo 1.0
 
 ApplicationWindow {
     id: window
@@ -543,6 +544,10 @@ ApplicationWindow {
                     exec = value;
                 } else if (arg === "Path") {
                     path = value;
+                } else if (arg === "TryExec") {
+                    if (!fileinfo.exexcutableFileExists(value)) {
+                        isShow = false;
+                    }
                 } else if (arg === "Terminal") {
                     if (value === "true") {
                         isShow = false;
@@ -808,6 +813,10 @@ ApplicationWindow {
     // For running command
     Process {
         id: process
+    }
+    // For finding command
+    FileInfo {
+        id: fileinfo
     }
 
 }

--- a/launcher/qml/main.qml
+++ b/launcher/qml/main.qml
@@ -44,12 +44,12 @@ ApplicationWindow {
     }
     // AudioVideo, Development, Education, Game, Graphics, Network, Office, Settings, System, Utility.
     property var categoryRule: {
-        "Programming": ["Development", "IDE", "ComputeSicence"],
+        "Programming": ["Development", "IDE", "ComputerScience"],
         "Education": ["Education", "Science", "Math"],
         "Office": ["Office"],
         "Internet": ["Network", "WebBrowser", "Email", "RemoteAccess"],
         "SoundNVideo": ["AudioVideo", "Player", "Recorder", "Audio", "Video", "Midi", "X-Alsa", "X-Jack"],
-        "Graphics": ["Graphics", "2DGraphics", "Phtography"],
+        "Graphics": ["Graphics", "2DGraphics", "Photography"],
         "Games": ["Game"],
         "Accessories": ["System", "Utility", "Archiving", "Compression", "ConsoleOnly", "Qt", "PackageManager", "FileTools", "FileManager", "TextEditor"],
         "Help": ["Help"],

--- a/launcher/qml/main.qml
+++ b/launcher/qml/main.qml
@@ -597,7 +597,6 @@ ApplicationWindow {
         }
         // log("categoriedAppList")
         // logObj(categoriedAppList)
-        reloadAppList();
     }
     function isFileExist(path) {
         var xhr = new XMLHttpRequest()
@@ -782,6 +781,7 @@ ApplicationWindow {
             loadFromFolderListModel(userApplicationsFolderList);
             loadFromFolderListModel(raspiUiOverridesApplicationsFolderList);
             loadFromFolderListModel(systemApplicationsFolderList);
+            reloadAppList();
             isLoadApplicationTriggered = false;
         }
     }

--- a/launcher/qml/main.qml
+++ b/launcher/qml/main.qml
@@ -555,8 +555,8 @@ ApplicationWindow {
                 isWhiteListed = true;
                 // log("White List: " + name);
             }
-            if (!isShow && !isWhiteListed) {
-                // log("Terminal App, Skip: " + url);
+            if (appData[name]) {
+                // application name has been already seen.
                 continue;
             }
             var added = false;
@@ -567,7 +567,8 @@ ApplicationWindow {
                 "appIcon": icon,
                 "appUrl": url,
                 "appExec": exec,
-                "appParam": param
+                "appParam": param,
+                "appIsShow" : isShow || isWhiteListed
             }
             // log("appData[" + name + "]:")
             // logObj(appData[name]);
@@ -671,6 +672,9 @@ ApplicationWindow {
             loader.source = "";
             appDraw.visible = true;
         } else {
+            if (!appData) {
+                return;
+            }
             var programs = categoriedAppList[currentCategory];
             // log("programs: " + programs);
             // log("programs.length: " + programs.length);
@@ -679,7 +683,9 @@ ApplicationWindow {
                 var app = appData[appName];
                 // log("app:");
                 // logObj(app);
-                appDrawList.append(app);
+                if (app && app.appIsShow) {
+                    appDrawList.append(app);
+                }
             }
         }
     }
@@ -694,6 +700,7 @@ ApplicationWindow {
             log("Icon: " + app.appIcon);
             log("Exec: " + app.appExec);
             log("Param: " + app.appParam);
+            log("isShow: " + app.appIsShow);
         }
     }
 

--- a/launcher/qml/main.qml
+++ b/launcher/qml/main.qml
@@ -379,7 +379,7 @@ ApplicationWindow {
                                 return;
                             }
                             var executable = result[0];
-                            var arguments = result.slice(1);
+                            var args = result.slice(1);
                             if (!fileinfo.exexcutableFileExists(executable)) {
                                 messageBox.text = "Invalid desktop file: '" + appUrl + "'";
                                 messageBox.open();
@@ -387,11 +387,11 @@ ApplicationWindow {
                             }
                             if (appInTerminal) {
                                 executable = "lxterminal"
-                                arguments = result;
-                                arguments.unshift("-e");
+                                args = result;
+                                args.unshift("-e");
                             }
                             process.setProgram(executable);
-                            process.setArguments(arguments);
+                            process.setArguments(args);
                             if (appPath) {
                                 process.setWorkingDirectory(appPath);
                             } else {

--- a/launcher/qml/main.qml
+++ b/launcher/qml/main.qml
@@ -51,7 +51,7 @@ ApplicationWindow {
         "SoundNVideo": ["AudioVideo", "Player", "Recorder", "Audio", "Video", "Midi", "X-Alsa", "X-Jack"],
         "Graphics": ["Graphics", "2DGraphics", "Photography"],
         "Games": ["Game"],
-        "Accessories": ["System", "Utility", "Archiving", "Compression", "ConsoleOnly", "Qt", "PackageManager", "FileTools", "FileManager", "TextEditor"],
+        "Accessories": ["System", "Utility", "Archiving", "Compression", "ConsoleOnly", "PackageManager", "FileTools", "FileManager", "TextEditor"],
         "Help": ["Help"],
         "Preferences": ["Settings"]
     }

--- a/launcher/qml/main.qml
+++ b/launcher/qml/main.qml
@@ -755,7 +755,7 @@ ApplicationWindow {
     // To load icons from folder list
     Timer {
         id: loadApplicationTimer
-        interval: 500
+        interval: 1
         running: false
         onTriggered: {
             if (isLoadApplicationTriggered) {

--- a/launcher/qml/run.qml
+++ b/launcher/qml/run.qml
@@ -18,6 +18,7 @@ Rectangle {
         top: parent.top
         topMargin: 80
     }
+    Component.onCompleted: input.forceActiveFocus()
 
     Text {
         id: label
@@ -38,6 +39,15 @@ Rectangle {
         width: parent.width - 200
         height: 40
         font.pointSize: 15
+
+        Keys.onEnterPressed: {
+            startCommand()
+            event.accepted = true
+        }
+        Keys.onReturnPressed: {
+            startCommand()
+            event.accepted = true
+        }
     }
 
     Rectangle {

--- a/launcher/qml/run.qml
+++ b/launcher/qml/run.qml
@@ -1,6 +1,7 @@
 import QtQuick 2.0
 import QtQuick.Controls 2.0
 import Process 1.0
+import "execvalueparser.js" as Parser
 //import QtQuick.VirtualKeyboard 2.2
 //import QtQuick.VirtualKeyboard.Settings 2.2
 
@@ -54,7 +55,37 @@ Rectangle {
         }
         MouseArea {
             anchors.fill: parent
-            onClicked: process.start(input.text, []);
+            onClicked: startCommand()
+        }
+    }
+
+    function startCommand() {
+        var result = Parser.doEscapingSecondLevelAndSplitArguments(input.text)
+        if (result.length === 0) {
+            messageBox.text = "Text is empty (or only consists of whitespace).";
+            messageBox.open();
+            return;
+        }
+        var executable = result[0];
+        var args = result.slice(1);
+        if (executable === '') {
+            messageBox.text = "Invalid command line!";
+            messageBox.open();
+            return;
+        }
+        process.setProgram(executable);
+        process.setArguments(args);
+        process.setWorkingDirectoryHome()
+        // Detach process from current stdin, stdout,
+        // stderr, so that especially console programs
+        // don't clutter the console of our launcher.
+        process.setStandardFilesToNull();
+
+        if (process.startDetached()) {
+            Qt.quit();
+        } else {
+           messageBox.text = "Error starting command!";
+           messageBox.open();
         }
     }
 /*

--- a/launcher/src/fileinfo.h
+++ b/launcher/src/fileinfo.h
@@ -1,0 +1,45 @@
+#include <QFileInfo>
+
+// class that is used as qml type with one (static) method.
+
+class FileInfo : public QObject {
+    Q_OBJECT
+
+public:
+    // If file is not an absolute path, look for file in $PATH.
+    // file must be an executable and must not have a relative path.
+    // Returns true if found, false otherwise.
+    Q_INVOKABLE bool exexcutableFileExists(const QString &file) {
+        char fileSeparator = '/';
+
+        if (file.isEmpty()) {
+            return false;
+        }
+        QFileInfo finfo;
+        if (file[0] == fileSeparator) {
+            // absolute path.
+            finfo.setFile(file);
+            return finfo.exists() && finfo.isFile() && finfo.isExecutable();
+        }
+        else if (file.indexOf(QChar(fileSeparator)) == -1) {
+            // no relative path.
+            QString envPath = QString::fromLocal8Bit(qgetenv("PATH"));
+            QStringList paths;
+            if (!envPath.isEmpty()) {
+                paths = envPath.split(QChar(':'));
+            }
+            foreach (QString path, paths) {
+                if (path.isEmpty()) {
+                    finfo.setFile(file);
+                }
+                else {
+                    finfo.setFile(path + fileSeparator + file);
+                }
+                if (finfo.exists() && finfo.isFile() && finfo.isExecutable()) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+};

--- a/launcher/src/main.cpp
+++ b/launcher/src/main.cpp
@@ -5,6 +5,7 @@
 #include <QObject>
 #include "process.h"
 #include "language.h"
+#include "fileinfo.h"
 
 int main(int argc, char **argv) {
     qputenv("QMLSCENE_DEVICE", "softwarecontext");
@@ -22,7 +23,8 @@ int main(int argc, char **argv) {
     Language language(app, engine);
 
     qmlRegisterType<Process>("Process", 1, 0, "Process");
-    
+    qmlRegisterType<FileInfo>("FileInfo", 1, 0, "FileInfo");
+
     engine.rootContext()->setContextProperty("language", &language);
     engine.load(QUrl("qrc:///launcher/qml/main.qml"));
 

--- a/launcher/src/process.h
+++ b/launcher/src/process.h
@@ -66,4 +66,11 @@ public:
     Q_INVOKABLE QProcess::ProcessState state() {
         return QProcess::state();
     }
+
+    Q_INVOKABLE void setStandardFilesToNull() {
+        QString nullDev = nullDevice();
+        setStandardInputFile(nullDev);
+        setStandardOutputFile(nullDev);
+        setStandardErrorFile(nullDev);
+    }
 };

--- a/launcher/src/process.h
+++ b/launcher/src/process.h
@@ -1,5 +1,6 @@
 #include <QProcess>
 #include <QVariant>
+#include <QDir>
 
 class Process : public QProcess {
     Q_OBJECT
@@ -18,12 +19,20 @@ public:
         QProcess::start(program, args);
     }
 
-    Q_INVOKABLE void startDetached(qint64 *pid = nullptr) {
-        QProcess::startDetached(pid);
+    Q_INVOKABLE bool startDetached(qint64 *pid = nullptr) {
+        return QProcess::startDetached(pid);
     }
 
     Q_INVOKABLE void setProgram(const QString &program) {
         QProcess::setProgram(program);
+    }
+
+    Q_INVOKABLE void setWorkingDirectory(const QString &dir) {
+        QProcess::setWorkingDirectory(dir);
+    }
+
+    Q_INVOKABLE void setWorkingDirectoryHome() {
+        QProcess::setWorkingDirectory(QDir::homePath());
     }
 
     Q_INVOKABLE void setArguments(const QVariantList &arguments) {

--- a/raspad-launcher.pro
+++ b/raspad-launcher.pro
@@ -33,7 +33,8 @@ DISTFILES += \
     launcher/images/shutdown.png \
     launcher/images/triangle.png \
     launcher/qml/main.qml\
-    launcher/qml/run.qml
+    launcher/qml/run.qml \
+    launcher/qml/execvalueparser.js
 
 SUBDIRS += \
     raspad-launcher.pro

--- a/raspad-launcher.pro
+++ b/raspad-launcher.pro
@@ -16,7 +16,8 @@ TRANSLATIONS += \
 
 HEADERS += \
     launcher/src/process.h \
-    launcher/src/language.h
+    launcher/src/language.h \
+    launcher/src/fileinfo.h
 
 DISTFILES += \
     launcher/images/Accessories.png \

--- a/raspad-launcher.qrc
+++ b/raspad-launcher.qrc
@@ -2,6 +2,7 @@
   <qresource prefix="/">
     <file>launcher/qml/main.qml</file>
     <file>launcher/qml/run.qml</file>
+    <file>launcher/qml/execvalueparser.js</file>
     <file>launcher/images/Internet.png</file>
     <file>launcher/images/Games.png</file>
     <file>launcher/images/Graphics.png</file>


### PR DESCRIPTION
Hi @sunfounder,

as suggested in pull request 2 ( https://github.com/raspad-tablet/raspad-launcher/pull/2#issuecomment-1015223163 ), I herewith submit my pull request for branch topic/rework-launching-application.
I added the QtQuick.Controls 1.2 to the installation script, Readme and installation-guide as you had suggested in pull request 2.
The branch is now in the state like you have tested it plus the change of the install script.

This branch offers:
- The launching of desktop-files compatible with Raspberry Pi OS system menu
- A Completed menu list by also loading all desktop files in /usr/share/raspi-ui-overrides/applications
- A slightly quicker program start 

In order to add to the install script, I had to rebase the branch of the purewasa/raspad-launcher repo.
So your copy of this repo now has an invalid history and you should delete it.

I hope this branch will satify your expectation.
