### PR TITLE
Topic/add missing desktop file keys

### DIFF
--- a/launcher/qml/main.qml
+++ b/launcher/qml/main.qml
@@ -478,22 +478,11 @@ ApplicationWindow {
                 // log("Read file Error: " + url);
                 continue;
             }
+            url = filePath;
 
             var contents = result.split("\n");
             var map = {};
-            var name = {};
-            var genericName = {};
-            var icon = "";
-            var exec = "";
-            var path = "";
-            // Use "uncategorized" category, in case no categories are given.
-            var categories = ["None"];
             var desktopType = "";
-            var inTerminal = false;
-            var isShow = true;
-            var isWhiteListed = false;
-            var locale = Qt.locale().name;
-            var lang = locale.substring(0,2);
 
             for (var j = 0; j < contents.length; j++) {
                 var line = contents[j];
@@ -519,12 +508,8 @@ ApplicationWindow {
                 map[arg] = value;
             }
 
-            name["lang_COUNTRY"] = map["Name[" + locale + "]"]
-            name["lang"] = map["Name[" + lang + "]"]
-            name["default"] = map["Name"]
-            genericName["lang_COUNTRY"] = map["GenericName[" + locale + "]"]
-            genericName["lang"] = map["GenericName[" + lang + "]"]
-            genericName["default"] = map["GenericName"]
+            // Use "uncategorized" category, in case no categories are given.
+            var categories = ["None"];
             if (map["Categories"]) {
                 categories = map["Categories"].split(";");
                 for (var k = 0; k < categories.length; k++) {
@@ -536,30 +521,19 @@ ApplicationWindow {
                     }
                 }
             }
-            if (map["Icon"]) {
-                icon = map["Icon"];
-            }
-            if (map["Exec"]) {
-                exec = map["Exec"];
-            }
-            if (map["Path"]) {
-                path = map["Path"];
-            }
+            var icon = map["Icon"] ? map["Icon"] : '';
+            var exec = map["Exec"] ? map["Exec"] : '';
+            var path = map["Path"] ? map["Path"] : '';
+
+            var isShow = true;
             if (map["TryExec"]) {
                 if (!fileinfo.exexcutableFileExists(map["TryExec"])) {
                     isShow = false;
                 }
             }
-            if (map["Terminal"]) {
-                if (map["Terminal"] === "true") {
-                    inTerminal = true;
-                }
-            }
-            if (map["NoDisplay"]) {
-                // log("NoDisplay true: " + url);
-                if (map["NoDisplay"] === "true") {
-                    isShow = false;
-                }
+            var inTerminal = map["Terminal"] === "true";
+            if (map["NoDisplay"] === "true") {
+                isShow = false;
             }
             if (map["NotShowIn"]) {
                 if (value === "GNOME;KDE;XFCE;MATE;") {
@@ -567,33 +541,34 @@ ApplicationWindow {
                 }
             }
 
-            url = filePath
-            var displayName = "";
-            var keyOrder = ["lang_COUNTRY", "lang", "default"];
-            for (var k = 0; k < keyOrder.length; k++) {
-                if (name[keyOrder[k]]) {
-                    displayName = name[keyOrder[k]];
-                    break;
-                }
+            var locale = Qt.locale().name;
+            var lang = locale.substring(0,2);
+
+            var displayName = map["Name[" + locale + "]"];
+            if (!displayName) {
+                displayName = map["Name[" + lang + "]"];
             }
             if (!displayName) {
-                for (var k = 0; k < keyOrder.length; k++) {
-                    if (genericName[keyOrder[k]]) {
-                        displayName = genericName[keyOrder[k]];
-                        break;
-                    }
-                }
+                displayName = map["Name"];
+            }
+            if (!displayName) {
+                displayName = map["GenericName[" + locale + "]"];
+            }
+            if (!displayName) {
+                displayName = map["GenericName[" + lang + "]"];
+            }
+            if (!displayName) {
+                displayName = map["GenericName"];
             }
             if (!displayName) {
                 isShow = false;
             }
+
             if (blacklist.indexOf(fileID) !== -1) {
                 isShow = false;
             }
-            if (whitelist.indexOf(fileID) !== -1) {
-                isWhiteListed = true;
-                // log("White List: " + fileID);
-            }
+            var isWhiteListed = whitelist.indexOf(fileID) !== -1;
+
             var added = false;
             appData[fileID] = {
                 "appName": fileID,

--- a/launcher/qml/main.qml
+++ b/launcher/qml/main.qml
@@ -7,6 +7,7 @@ import Qt.labs.folderlistmodel 2.0
 import QtQuick.Dialogs 1.1
 import "execvalueparser.js" as Parser
 import FileInfo 1.0
+import ProcessEnvironment 1.0
 
 ApplicationWindow {
     id: window
@@ -457,6 +458,8 @@ ApplicationWindow {
         // log("loadFromFolderListModel(")
         // logFolderList(folderList)
         // log(")")
+        var curDesktops = environment.getenv("XDG_CURRENT_DESKTOP").split(';');
+
         var all_categories = [];
         var desktops = [];
         for (var i = 0; i < folderList.count; i++) {
@@ -526,6 +529,26 @@ ApplicationWindow {
             var path = map["Path"] ? map["Path"] : '';
 
             var isShow = true;
+            var onlyShowIn = map["OnlyShowIn"];
+            if (onlyShowIn) {
+                isShow = false;
+                for (var k = 0; k < curDesktops.length; k++) {
+                    if (onlyShowIn.indexOf(curDesktops[k]) !== -1) {
+                        isShow = true;
+                        break;
+                    }
+                }
+            }
+            var notShowIn = map["NotShowIn"];
+            if (notShowIn) {
+                for (var k = 0; k < curDesktops.length; k++) {
+                    if (notShowIn.indexOf(curDesktops[k]) !== -1) {
+                        isShow = false;
+                        break;
+                    }
+                }
+            }
+
             if (map["TryExec"]) {
                 if (!fileinfo.exexcutableFileExists(map["TryExec"])) {
                     isShow = false;
@@ -534,11 +557,6 @@ ApplicationWindow {
             var inTerminal = map["Terminal"] === "true";
             if (map["NoDisplay"] === "true") {
                 isShow = false;
-            }
-            if (map["NotShowIn"]) {
-                if (value === "GNOME;KDE;XFCE;MATE;") {
-                    isShow = false;
-                }
             }
 
             var locale = Qt.locale().name;
@@ -799,6 +817,10 @@ ApplicationWindow {
     // For finding command
     FileInfo {
         id: fileinfo
+    }
+    // For accessing the environment
+    ProcessEnvironment {
+        id: environment
     }
 
 }

--- a/launcher/qml/main.qml
+++ b/launcher/qml/main.qml
@@ -480,6 +480,7 @@ ApplicationWindow {
             }
 
             var contents = result.split("\n");
+            var map = {};
             var name = {};
             var genericName = {};
             var icon = "";
@@ -515,69 +516,57 @@ ApplicationWindow {
                 }
                 var arg = line.slice(0, equalPos);
                 var value = line.slice(equalPos + 1);
+                map[arg] = value;
+            }
 
-                var match = arg.match(/^Name(\[([a-zA-Z0-9_@-]+)])?/);
-                if (match) {
-                    // Index 0 = whole matched string.
-                    // Index 2 = matched lang_COUNTRY string.
-                    if (match[2] === locale) {
-                        name["lang_COUNTRY"] = value;
-                    } else if (match[2] === lang) {
-                        name["lang"] = value;
-                    } else if (match[0] === "Name") {
-                        name["default"] = value;
-                    }
-                    continue;
-                }
-                match = arg.match(/^GenericName(\[([a-zA-Z0-9_@-]+)])?/);
-                if (match) {
-                    // Index 0 = whole matched string.
-                    // Index 2 = matched lang_COUNTRY string.
-                    if (match[2] === locale) {
-                        genericName["lang_COUNTRY"] = value;
-                    } else if (match[2] === lang) {
-                        genericName["lang"] = value;
-                    } else if (match[0] === "GenericName") {
-                        genericName["default"] = value;
-                    }
-                    continue;
-                }
-                if (arg === "Categories") {
-                    categories = value.split(";");
-                    for (var k = 0; k < categories.length; k++) {
-                        var category = categories[k];
-                        if (category === "") {
-                            continue;
-                        }
+            name["lang_COUNTRY"] = map["Name[" + locale + "]"]
+            name["lang"] = map["Name[" + lang + "]"]
+            name["default"] = map["Name"]
+            genericName["lang_COUNTRY"] = map["GenericName[" + locale + "]"]
+            genericName["lang"] = map["GenericName[" + lang + "]"]
+            genericName["default"] = map["GenericName"]
+            if (map["Categories"]) {
+                categories = map["Categories"].split(";");
+                for (var k = 0; k < categories.length; k++) {
+                    var category = categories[k];
+                    if (category !== "") {
                         if (all_categories.indexOf(category) === -1) {
                             all_categories.push(category)
                         }
                     }
-                } else if (arg === "Icon") {
-                    icon = value;
-                } else if (arg === "Exec") {
-                    exec = value;
-                } else if (arg === "Path") {
-                    path = value;
-                } else if (arg === "TryExec") {
-                    if (!fileinfo.exexcutableFileExists(value)) {
-                        isShow = false;
-                    }
-                } else if (arg === "Terminal") {
-                    if (value === "true") {
-                        inTerminal = true;
-                    }
-                } else if (arg === "NoDisplay") {
-                    // log("NoDisplay true: " + url);
-                    if (value === "true") {
-                        isShow = false;
-                    }
-                } else if (arg === "NotShowIn") {
-                    if (value === "GNOME;KDE;XFCE;MATE;") {
-                        isShow = false;
-                    }
                 }
             }
+            if (map["Icon"]) {
+                icon = map["Icon"];
+            }
+            if (map["Exec"]) {
+                exec = map["Exec"];
+            }
+            if (map["Path"]) {
+                path = map["Path"];
+            }
+            if (map["TryExec"]) {
+                if (!fileinfo.exexcutableFileExists(map["TryExec"])) {
+                    isShow = false;
+                }
+            }
+            if (map["Terminal"]) {
+                if (map["Terminal"] === "true") {
+                    inTerminal = true;
+                }
+            }
+            if (map["NoDisplay"]) {
+                // log("NoDisplay true: " + url);
+                if (map["NoDisplay"] === "true") {
+                    isShow = false;
+                }
+            }
+            if (map["NotShowIn"]) {
+                if (value === "GNOME;KDE;XFCE;MATE;") {
+                    isShow = false;
+                }
+            }
+
             url = filePath
             var displayName = "";
             var keyOrder = ["lang_COUNTRY", "lang", "default"];

--- a/launcher/qml/main.qml
+++ b/launcher/qml/main.qml
@@ -511,6 +511,10 @@ ApplicationWindow {
                 map[arg] = value;
             }
 
+            if (map["Type"] !== "Application") {
+                continue;
+            }
+
             // Use "uncategorized" category, in case no categories are given.
             var categories = ["None"];
             if (map["Categories"]) {

--- a/launcher/src/main.cpp
+++ b/launcher/src/main.cpp
@@ -13,6 +13,8 @@ int main(int argc, char **argv) {
     qputenv("QT_IM_MODULE", "qtvirtualkeyboard");
     qputenv("QT_PQA_PLATFORM", "xcb");
     qputenv("QT_XCB_GL_INTEGRATION", "xcb_egl");
+    // Enable file:// access in XMLHttpRequest in main.qml
+    qputenv("QML_XHR_ALLOW_FILE_READ", "1");
 
     QGuiApplication app(argc, argv);
 

--- a/launcher/src/main.cpp
+++ b/launcher/src/main.cpp
@@ -6,6 +6,7 @@
 #include <QTranslator>
 #include "process.h"
 #include "fileinfo.h"
+#include "processenvironment.h"
 
 int main(int argc, char **argv) {
     qputenv("QMLSCENE_DEVICE", "softwarecontext");
@@ -29,6 +30,7 @@ int main(int argc, char **argv) {
 
     qmlRegisterType<Process>("Process", 1, 0, "Process");
     qmlRegisterType<FileInfo>("FileInfo", 1, 0, "FileInfo");
+    qmlRegisterType<ProcessEnvironment>("ProcessEnvironment", 1, 0, "ProcessEnvironment");
 
     engine.load(QUrl("qrc:///launcher/qml/main.qml"));
 

--- a/launcher/src/processenvironment.h
+++ b/launcher/src/processenvironment.h
@@ -1,0 +1,20 @@
+#include <QObject>
+
+class ProcessEnvironment : public QObject {
+    Q_OBJECT
+
+public:
+    ProcessEnvironment(QObject *parent = 0) : QObject(parent) {}
+
+    Q_INVOKABLE QString getenv(const QString &varName) {
+        return QString::fromLocal8Bit(qgetenv(varName.toLocal8Bit().constData()));
+    }
+
+    Q_INVOKABLE bool putenv(const QString &varName, const QString &value) {
+       return qputenv(varName.toLocal8Bit().constData(), value.toLocal8Bit());
+    }
+
+    Q_INVOKABLE bool unsetenv(const QString &varName) {
+        return qunsetenv(varName.toLocal8Bit().constData());
+    }
+};

--- a/raspad-launcher.pro
+++ b/raspad-launcher.pro
@@ -16,7 +16,8 @@ TRANSLATIONS += \
 
 HEADERS += \
     launcher/src/process.h \
-    launcher/src/fileinfo.h
+    launcher/src/fileinfo.h \
+    launcher/src/processenvironment.h
 
 DISTFILES += \
     launcher/images/Accessories.png \


### PR DESCRIPTION
Hi @sunfounder and @cavonlee,

I still have two more branches that I like to offer as a contribution.
I've already mainly prepared them in last November.

With this PR, I want to submit the first of the two.

It adds parsing of three more .desktop file keys: "Type", "OnlyShowIn" and "NotShowIn".

To make adding easier, I first refactored main.qml in two steps, so that
an associative array (javascript object) is now used to store the key/value
pairs of the .desktop file.
This also makes adding further missing keys very easy, as there are still
some more keys to be implemented like "Version" or "Comment".
See: https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#recognized-keys

Adding the keys "OnlyShowIn" and "NotShowIn" causes the "keyboard and mouse" setting
icon (lxinput) to appear on preferences page. lxinput is also part of
the preferences submenu of the original system menu of Raspberry Pi OS and
allows to change doubleclick speed, for example. See: https://github.com/purewasa/raspad-launcher/commit/e0b758048d7e6df229aab402152a55887ec79348

Adding the "Type" key, makes the entry "Openbox" (openbox.desktop) on the accessories
page disappear. This icon wants to start an X window manager session of openbox,
which does fail, and should be prohibited. It also is not part of the original
system menu. See: https://github.com/purewasa/raspad-launcher/commit/c8cf0a6191df7451ba11d807491af444d28d9753

I also added a fix for the warning, that is issued several times when using
bullseye with Qt 5.15.2. See the commit message of https://github.com/purewasa/raspad-launcher/commit/3ec6d4c5ec2414e596e52e43b7227e30fc86997e for details.

I hope, you still like adding some more improvements.
