### PR TITLE
Topic/onboard workaround

### DIFF
--- a/launcher/qml/main.qml
+++ b/launcher/qml/main.qml
@@ -176,6 +176,7 @@ ApplicationWindow {
                 bottomMargin: 9
                 margins: 2
             }
+            ScrollBar.vertical: ScrollBar{}
             model: categoryList
             delegate: Button {
                 width: 242
@@ -309,6 +310,7 @@ ApplicationWindow {
                 topMargin: 30
                 bottomMargin: 62
             }
+            ScrollBar.vertical: ScrollBar{}
             model: appDrawList
             delegate: Column {
                 Rectangle {

--- a/launcher/qml/main.qml
+++ b/launcher/qml/main.qml
@@ -21,6 +21,12 @@ ApplicationWindow {
     flags: Qt.FramelessWindowHint
     title: 'RasPad Launcher'
 
+    onActiveChanged: {
+        if (!active) {
+            Qt.quit()
+        }
+    }
+
     property string settime
     property int iconGridWidth: 178
     property int iconGridHeight: 200

--- a/launcher/qml/main.qml
+++ b/launcher/qml/main.qml
@@ -13,6 +13,8 @@ ApplicationWindow {
     id: window
     x: 0
     y: 0
+    width: Screen.width
+    height: Screen.height
     color: 'white'
     visible: true
     visibility: "FullScreen"
@@ -195,8 +197,11 @@ ApplicationWindow {
                     // log("currentCategory: "+ currentCategory);
                     if (categoriedAppList[currentCategory] === undefined) {
                         loader.source = model.page.toLowerCase() + ".qml";
+                        window.visibility = "Windowed"
+                        window.showMaximized()
                     } else {
                         reloadAppList(model.name);
+                        window.showFullScreen()
                     }
                 }
                 background: Rectangle {

--- a/launcher/qml/main.qml
+++ b/launcher/qml/main.qml
@@ -166,7 +166,7 @@ ApplicationWindow {
             id: listView
             width: 242
             clip: true
-            interactive: false
+            boundsBehavior: Flickable.StopAtBounds
             anchors {
                 top: logo.bottom
                 left: parent.left
@@ -176,7 +176,6 @@ ApplicationWindow {
                 bottomMargin: 9
                 margins: 2
             }
-            ScrollBar.vertical: ScrollBar{}
             model: categoryList
             delegate: Button {
                 width: 242


### PR DESCRIPTION
Hi @sunfounder, hi @cavonlee,

thanks for merging my last PR.

This PR, now, is the last one of my work already done in last November.
I guess, it is the most controversial one, because I assume, that users
of the RasPad 3 tablet will use the virtual keyboard from the onboard package.

You recommend this keyboard in your Raspad 3 Docs "QUICK USER GUIDE"
( https://docs.raspad.com/en/latest/install_virtual_keyboard.html ).
But I don't know, how much I can rely on the onboard keyboard being
installed and running.
That is, why I put it as my last contribution.

The problem with the onboard keyboard is, that, with the settings from the "QUICK
USER GUIDE", it is not showing when a window is fullscreen. Since raspad-launcher
runs as fullscreen, entering the "Run" page does not let the keyboard appear,
so there is no way to enter a command in the edit field.
But if you cannot enter a command the "Run" page is futile!

There are several bug reports on the onboard fullscreen problem. I present
two of them here:
- https://bugs.launchpad.net/onboard/+bug/1627819
- https://bugs.launchpad.net/onboard/+bug/1722271

They say, it is the option "Dock to screen edge", which is not
working properly.

So, leaving the options set as you recommend in the "QUICK USER GUIDE",
I made a workaround (5375d6361f118ccd4f79965a160784548f949030):
When choosing the "Run" page in raspad-launcher, it changes the fullscreen
window to a maximized window.
And when choosing another page reverts back to fullscreen window.
This lets the keyboard appear as soon as you select the "Run" page
and disappear on the other pages.

With this workaround, the user will see the taskbar when the window is
maximized. So now, he or she can accidentially, click on an application
button on the taskbar, which will bring the according application to
front. At the same time raspad-launcher remains open.
I considered that an unwanted situation and extended my workaround by
closing raspad-launcher when deactivated
(956f3eb4f8176006da95b91cf0aa3db4eb020486).
This, I guess, is something to discuss about.
It also has the effect, that when pressing ALT-Tab on a (real) keyboard,
raspad-launcher is stopped and vanishes.

When the raspad-launcher window is maximized, the categories list on the
left is partially hidden. I noticed that the list is not draggable. So, I finally
also added support for being draggable
(b674e8263cd2a81ea1f45cdd88d688f2638a49fb)
and showing scrollbars (4d3213e944a33c23e23cc6ebde510a4fcd71e321)

So, take a look and let me know what you think about!

Kind regards!
