### PR TITLE
Topic/load from all xdg data dirs

### DIFF
--- a/launcher/qml/main.qml
+++ b/launcher/qml/main.qml
@@ -795,7 +795,7 @@ ApplicationWindow {
         }
     }
 
-    // To load icons from folder list
+    // Load *.desktop files from folder lists.
     Timer {
         id: loadApplicationTimer
         interval: 1

--- a/launcher/qml/main.qml
+++ b/launcher/qml/main.qml
@@ -70,8 +70,8 @@ ApplicationWindow {
         "Help": ["Help"],
         "Preferences": ["Settings"]
     }
-    property var blacklist: ["squeak.desktop", "wolfram-language.desktop"]
-    property var whitelist: ["arandr.desktop", "rp-bookshelf.desktop"]
+    property var blacklist: ["wolfram-language.desktop"]
+    property var whitelist: []
     property var currentCategory: "Home"
 
     property string errorNetwork: qsTr("Network Error")

--- a/launcher/qml/main.qml
+++ b/launcher/qml/main.qml
@@ -8,6 +8,7 @@ import QtQuick.Dialogs 1.1
 import "execvalueparser.js" as Parser
 import FileInfo 1.0
 import ProcessEnvironment 1.0
+import "xdgdirectories.js" as XDGDirs
 
 ApplicationWindow {
     id: window
@@ -645,7 +646,7 @@ ApplicationWindow {
 
     function generateIconSearchDirs() {
         var iconDirs = []
-        var iconBaseDirs = ["/usr/share/icons"]
+        var iconBaseDirs = XDGDirs.getXDGDataDirsSubdirs("icons");
 
         for (var i = 0; i < iconBaseDirs.length; i++) {
             var themes = ["PiXflat", "hicolor", "gnome"];

--- a/launcher/qml/main.qml
+++ b/launcher/qml/main.qml
@@ -355,9 +355,9 @@ ApplicationWindow {
                                 }
                                 result = _icon
                             } else {
-                                result = "file://" + appIcon
+                                result = appIcon
                             }
-                            return result
+                            return "file://" + result
                         }
                         anchors {
                             horizontalCenter: parent.horizontalCenter
@@ -640,18 +640,6 @@ ApplicationWindow {
         // log("categoriedAppList")
         // logObj(categoriedAppList)
     }
-    function isFileExist(path) {
-        var xhr = new XMLHttpRequest()
-        xhr.open("GET", path, false)
-        xhr.send()
-        if (xhr.readyState !== 4) {
-            return false
-        }
-        if (xhr.status !== 200) {
-            return false
-        }
-        return true
-    }
     function getIconPath(icon) {
         var testList = [
             "/usr/share/icons/PiXflat/256x256/apps/",
@@ -687,16 +675,16 @@ ApplicationWindow {
             "/usr/share/pixmaps/"
         ];
         for (var i = 0; i < testList.length; i++) {
-            var path_pre = "file://" + testList[i] + icon
+            var path_pre = testList[i] + icon
             var path = path_pre
             if (icon.indexOf(".png") == -1 && icon.indexOf(".svg") == -1) {
                 path = path_pre + ".png"
-                if (isFileExist(path)) {
+                if (fileinfo.isFile(path)) {
                     return path
                 }
                 path = path_pre + ".svg"
             }
-            if (isFileExist(path)) {
+            if (fileinfo.isFile(path)) {
                 return path
             }
         }

--- a/launcher/qml/main.qml
+++ b/launcher/qml/main.qml
@@ -70,6 +70,8 @@ ApplicationWindow {
 
     property string errorNetwork: qsTr("Network Error")
 
+    property var iconDirs: generateIconSearchDirs()
+
     // Panel
     Rectangle {
         id: panel
@@ -640,42 +642,45 @@ ApplicationWindow {
         // log("categoriedAppList")
         // logObj(categoriedAppList)
     }
+
+    function generateIconSearchDirs() {
+        var iconDirs = []
+        var iconBaseDirs = ["/usr/share/icons"]
+
+        for (var i = 0; i < iconBaseDirs.length; i++) {
+            var themes = ["PiXflat", "hicolor", "gnome"];
+
+            for (var j = 0; j < themes.length; j++) {
+                var themeDir = iconBaseDirs[i] + "/" + themes[j];
+                if (!fileinfo.isDir(themeDir)) {
+                    continue;
+                }
+                var sections = ["apps", "devices", "places" , "categories"];
+
+                for (var k = 0; k < sections.length; k++) {
+                    var resolutions = ["256x256", "128x128", "64x64",
+                                       "48x48", "32x32", "scalable"];
+
+                    for (var l = 0; l < resolutions.length; l++) {
+                        var iconDir = themeDir + "/" + resolutions[l]
+                                           + "/" + sections[k] + "/";
+                        if (fileinfo.isDir(iconDir)) {
+                            iconDirs.push(iconDir);
+                        }
+                    }
+                }
+            }
+        }
+        iconDirs.push("/usr/share/pixmaps/");
+        // log("iconDirs (" + iconDirs.length + ")")
+        // logList(iconDirs);
+
+        return iconDirs;
+    }
+
     function getIconPath(icon) {
-        var testList = [
-            "/usr/share/icons/PiXflat/256x256/apps/",
-            "/usr/share/icons/PiXflat/128x128/apps/",
-            "/usr/share/icons/PiXflat/64x64/apps/",
-            "/usr/share/icons/PiXflat/48x48/apps/",
-            "/usr/share/icons/PiXflat/256x256/devices/",
-            "/usr/share/icons/PiXflat/128x128/devices/",
-            "/usr/share/icons/PiXflat/64x64/devices/",
-            "/usr/share/icons/PiXflat/48x48/devices/",
-            "/usr/share/icons/PiXflat/256x256/places/",
-            "/usr/share/icons/PiXflat/128x128/places/",
-            "/usr/share/icons/PiXflat/64x64/places/",
-            "/usr/share/icons/PiXflat/48x48/places/",
-            "/usr/share/icons/PiXflat/256x256/categories/",
-            "/usr/share/icons/PiXflat/128x128/categories/",
-            "/usr/share/icons/PiXflat/64x64/categories/",
-            "/usr/share/icons/PiXflat/48x48/categories/",
-            "/usr/share/icons/hicolor/256x256/apps/",
-            "/usr/share/icons/hicolor/128x128/apps/",
-            "/usr/share/icons/hicolor/64x64/apps/",
-            "/usr/share/icons/hicolor/48x48/apps/",
-            "/usr/share/icons/hicolor/32x32/apps/",
-            "/usr/share/icons/hicolor/scalable/apps/",
-            "/usr/share/icons/gnome/256x256/apps/",
-            "/usr/share/icons/gnome/128x128/apps/",
-            "/usr/share/icons/gnome/64x64/apps/",
-            "/usr/share/icons/gnome/48x48/apps/",
-            "/usr/share/icons/gnome/256x256/devices/",
-            "/usr/share/icons/gnome/128x128/devices/",
-            "/usr/share/icons/gnome/64x64/devices/",
-            "/usr/share/icons/gnome/48x48/devices/",
-            "/usr/share/pixmaps/"
-        ];
-        for (var i = 0; i < testList.length; i++) {
-            var path_pre = testList[i] + icon
+        for (var i = 0; i < iconDirs.length; i++) {
+            var path_pre = iconDirs[i] + icon
             var path = path_pre
             if (icon.indexOf(".png") == -1 && icon.indexOf(".svg") == -1) {
                 path = path_pre + ".png"

--- a/launcher/qml/main.qml
+++ b/launcher/qml/main.qml
@@ -645,7 +645,7 @@ ApplicationWindow {
                 if (!fileinfo.isDir(themeDir)) {
                     continue;
                 }
-                var sections = ["apps", "devices", "places" , "categories"];
+                var sections = ["apps", "devices", "places" , "categories", "status"];
 
                 for (var k = 0; k < sections.length; k++) {
                     var resolutions = ["256x256", "128x128", "64x64",

--- a/launcher/qml/main.qml
+++ b/launcher/qml/main.qml
@@ -763,7 +763,7 @@ ApplicationWindow {
     function readFile(file, raw) {
         var base = ""
         if (raw !== true) {
-            base = "file:///home/pi/.config/raspad/"
+            base = "file://" + XDGDirs.getXDGConfigHomeDir() + "/raspad/"
         }
         var read = new XMLHttpRequest()
         read.open("GET", base + file, false)

--- a/launcher/qml/main.qml
+++ b/launcher/qml/main.qml
@@ -775,9 +775,10 @@ ApplicationWindow {
     }
 
     function createFolderListModels() {
-        var appFolders = ["/home/pi/.local/share/applications",
-                          "/usr/share/raspi-ui-overrides/applications",
-                          "/usr/share/applications"];
+        var appFolders = XDGDirs.getXDGDataDirsSubdirs("applications");
+        // log("appFolders");
+        // logList(appFolders);
+
         appFolderListModels = [];
         for (var i = 0; i < appFolders.length; i++) {
              var appFolderListModel =

--- a/launcher/qml/main.qml
+++ b/launcher/qml/main.qml
@@ -30,6 +30,7 @@ ApplicationWindow {
 
     Component.onCompleted: {
         createFolderListModels();
+        iconDirs = generateIconSearchDirs();
         loadApplicationTimer.start();
     }
 
@@ -76,7 +77,7 @@ ApplicationWindow {
 
     property string errorNetwork: qsTr("Network Error")
 
-    property var iconDirs: generateIconSearchDirs()
+    property var iconDirs: []
     property var appFolderListModels: []
 
     // Panel

--- a/launcher/qml/xdgdirectories.js
+++ b/launcher/qml/xdgdirectories.js
@@ -21,6 +21,15 @@
         return dataHomeDir;
     }
 
+    function getXDGConfigHomeDir() {
+        var configHomeDir = environment.getenv("XDG_CONFIG_HOME");
+        if (configHomeDir === "") {
+            // Use default according to "XDG Base Directory Specification".
+            configHomeDir = getHomeDir() + "/.config";
+        }
+        return configHomeDir;
+    }
+
     function getXDGDataDirs() {
         var dataDirs = environment.getenv("XDG_DATA_DIRS");
         if (dataDirs === "") {

--- a/launcher/qml/xdgdirectories.js
+++ b/launcher/qml/xdgdirectories.js
@@ -1,0 +1,51 @@
+// Provide functions to read the $HOME and $XDG_DATA_* environment variables
+// and to collect all existing subdirs of paths in $XDG_DATA_*.
+// This javascript resource is only meant to be imported by main.qml as it
+// requires the objects enviroment and fileinfo from ApplicationWindow window.
+
+    function getHomeDir() {
+        var homeDir = environment.getenv("HOME");
+        if (homeDir === "") {
+            // Use default.
+            homeDir = "/home/pi";
+        }
+        return homeDir;
+    }
+
+    function getXDGDataHomeDir() {
+        var dataHomeDir = environment.getenv("XDG_DATA_HOME");
+        if (dataHomeDir === "") {
+            // Use default according to "XDG Base Directory Specification".
+            dataHomeDir = getHomeDir() + "/.local/share";
+        }
+        return dataHomeDir;
+    }
+
+    function getXDGDataDirs() {
+        var dataDirs = environment.getenv("XDG_DATA_DIRS");
+        if (dataDirs === "") {
+            // Use default according to "XDG Base Directory Specification".
+            dataDirs = "/usr/local/share:/usr/share";
+        }
+        return dataDirs;
+    }
+
+    // Get list of all existing directories of the form $XDG_DATA_HOME/subdir
+    // and $XDG_DATA_DIRS/subdir in the given order of preference.
+    function getXDGDataDirsSubdirs(subdir) {
+        var baseDirs = [getXDGDataHomeDir()].concat(getXDGDataDirs().split(':'));
+
+        var subdirs = [];
+        for (var i = 0; i < baseDirs.length; i++) {
+            if (fileinfo.isRelative(baseDirs[i])) {
+                // Ignore relative paths according to
+                // "XDG Base Directory Specification".
+                continue;
+            }
+            var dir = baseDirs[i] + "/" + subdir;
+            if (fileinfo.isDir(dir)) {
+                subdirs.push(dir);
+            }
+        }
+        return subdirs
+    }

--- a/launcher/src/fileinfo.h
+++ b/launcher/src/fileinfo.h
@@ -1,6 +1,6 @@
 #include <QFileInfo>
 
-// class that is used as qml type with one (static) method.
+// class that is used as qml type with five (static) methods.
 
 class FileInfo : public QObject {
     Q_OBJECT
@@ -41,5 +41,29 @@ public:
             }
         }
         return false;
+    }
+
+    // Checks, if path exists and is a file, not a directory.
+    Q_INVOKABLE bool isFile(const QString &path) {
+        QFileInfo finfo(path);
+        return finfo.isFile();
+    }
+
+    // Checks, if path exists and is a directory.
+    Q_INVOKABLE bool isDir(const QString &path) {
+        QFileInfo finfo(path);
+        return finfo.isDir();
+    }
+
+    // Checks, if path is absolute.
+    Q_INVOKABLE bool isAbsolute(const QString &path) {
+        QFileInfo finfo(path);
+        return finfo.isAbsolute();
+    }
+
+    // Checks, if path is relative.
+    Q_INVOKABLE bool isRelative(const QString &path) {
+        QFileInfo finfo(path);
+        return finfo.isRelative();
     }
 };

--- a/raspad-launcher.qrc
+++ b/raspad-launcher.qrc
@@ -3,6 +3,7 @@
     <file>launcher/qml/main.qml</file>
     <file>launcher/qml/run.qml</file>
     <file>launcher/qml/execvalueparser.js</file>
+    <file>launcher/qml/xdgdirectories.js</file>
     <file>launcher/images/Internet.png</file>
     <file>launcher/images/Games.png</file>
     <file>launcher/images/Graphics.png</file>


### PR DESCRIPTION
Hi @sunfunder, hi @cavonlee,

I am back again with new code extending raspad-launcher.
Now, having a RasPad 3 on my own for almost half a year, I am using raspad-launcher quite frequently, and it feels great!
(Btw, I am running RasPad with Raspberry Pi OS bullseye and mutter with some modifications, and I think bullseye is a bit more adapted to a touchscreen than buster.)
But when I had been installing a certain program under /usr/local, it was not listed in the menus of raspad-launcher!
It turned out, that it is a disadvantage that the code uses hard-coded directory names for the *.desktop files and images, because that program installs the *.desktop file under /usr/local/share/applications and its icons under /usr/local/share/icons. These directories are not searched for by the launcher.
To overcome this shortcoming, I've made the list of directories to search for dynamic and use all directories given in the environment variables $XDG_DATA_DIRS and $XDG_DATA_HOME. These are specified in the "XDG Base Directory Specification" of freedesktop.org: https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
You can display these variables by opening lxterminal with raspad-launcher or on the desktop and enter the command line : `printenv | grep XDG | sort`
Now, even /usr/local/share and /usr/share/fkms/ are being searched through, so that my new program is now listed by raspad-laucher showing the right icons!
With all these directories being included, most black and white listed applications are now loaded (or blocked	) correctly without being listed!

I also made raspad-launcher binary generic in respect to the user. All file paths are now all based on $HOME or $XDG_* directories. There is no hard-coded /home/pi in the sources anymore, except for the unlikely case that $HOME is empty or unset.

There still is /home/pi in the uninstall script. But I did not change it, because I have no way to test it. This I leave up to you!

I tested these changes on buster and bullseye with no problems. The startup time didn't really changed (less than 100 ms more), so there is no real difference noticeable!

Apart from this branch I have another commit, that I like to contribute. But since it covers another topic, I will present it to you in a next PR, when this one will have been merged by you. 
 
I hope, you like my changes, and I am looking forward to hearing from you.

Kind regards,

purewasa