### PR TITLE
Show window on startup only after all application files are loaded

### DIFF
--- a/launcher/qml/main.qml
+++ b/launcher/qml/main.qml
@@ -17,8 +17,6 @@ ApplicationWindow {
     width: Screen.width
     height: Screen.height
     color: 'white'
-    visible: true
-    visibility: "FullScreen"
     flags: Qt.FramelessWindowHint
     title: 'RasPad Launcher'
 
@@ -817,6 +815,7 @@ ApplicationWindow {
                 loadFromFolderListModel(appFolderListModels[i]);
             }
             reloadAppList();
+            visibility = "FullScreen";
             isLoadApplicationTriggered = false;
         }
     }


### PR DESCRIPTION
 Hi  @sunfounder, hi @cavonlee,

here now my second and, so far, last PR.
I wasn't pleased with the startup of raspad-laucher: 

The startup behaviour before was:
- show the main window with no icons in the GridView, first,
- load all application files (in about 450 ms), and
- finally show icons in GridView.

This caused in me the impression, that I have to watch the program getting ready, and a feeeling that these 450ms before the icons appear take very long. I found this tiring.
So, I wanted to change this. I wanted to make it look appearing quicker.

With this PR the startup behaviour is:
- load all application files, first,
- show the main window, completely with all icons.

This improves the "first impression" of raspad-launcher in the sense, that the first glance that you catch at startup is already the complete view. You don't have to watch the program getting ready, anymore.
This makes it feel a lot more snappier!

The duration until the main window is completely shown and ready to use, remains the same. But the feeling is, that it is quicker.

I hope you can share my experience and find the startup better this way!

I'm looking forward to hearing from you.

Kind regards,

purewasa